### PR TITLE
Implemented image prefetching label overlap fix

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -85,3 +85,4 @@ fastlane/test_output
 iOSInjectionProject/
 
 # End of https://www.toptal.com/developers/gitignore/api/swift
+*.plist

--- a/Cart Crunch.xcodeproj/xcuserdata/tizzymatic.xcuserdatad/xcschemes/xcschememanagement.plist
+++ b/Cart Crunch.xcodeproj/xcuserdata/tizzymatic.xcuserdatad/xcschemes/xcschememanagement.plist
@@ -7,7 +7,7 @@
 		<key>Cart Crunch.xcscheme_^#shared#^_</key>
 		<dict>
 			<key>orderHint</key>
-			<integer>1</integer>
+			<integer>0</integer>
 		</dict>
 		<key>ParseSwift (Playground) 1.xcscheme</key>
 		<dict>

--- a/Cart Crunch/HomeScreenTableViewCell.swift
+++ b/Cart Crunch/HomeScreenTableViewCell.swift
@@ -64,7 +64,7 @@ class HomeScreenTableViewCell: UITableViewCell {
     //MARK: - Configuration
     //this is hard coded for now but eventually we will pass data from the api here
     //we can use the nuke package again to grab the image from the api
-    func configure(with product: Product) {
+    func configure(with product: Product, findImageURL: (_ images: [ImageMetaData], _ sizeName: String) -> String?) {
         
         productNameLabel.text = product.description
         
@@ -78,16 +78,17 @@ class HomeScreenTableViewCell: UITableViewCell {
         
         productNewPriceLabel.text = String(product.items.first?.price?.regular ?? 0)
         
-        let desiredSizeName = "medium" // Change this to the size name you want to use
-        guard let imageURLString = findImageURL(for: product.images.first?.sizes ?? [], sizeName: desiredSizeName) else { return }
-        let imageURL = URL(string: imageURLString)
-        Nuke.loadImage(with: imageURL!, into: productImageView)
+        let desiredSizeName = "medium"
+        guard let imageURLString = findImageURL(product.images.first?.sizes ?? [], desiredSizeName) else { return }
+        if let imageURL = URL(string: imageURLString) {
+            Nuke.loadImage(with: imageURL, into: productImageView)
+        }
 
     }
     
-    func findImageURL(for images: [ImageMetaData], sizeName: String) -> String? {
-        return images.first(where: { $0.size == sizeName })?.url
-    }
+//    func findImageURL(for images: [ImageMetaData], sizeName: String) -> String? {
+//        return images.first(where: { $0.size == sizeName })?.url
+//    }
 
     //MARK: - Setup UI
     private func setupUI() {
@@ -110,6 +111,7 @@ class HomeScreenTableViewCell: UITableViewCell {
             
             productNameLabel.topAnchor.constraint(equalTo: productImageView.topAnchor),
             productNameLabel.leadingAnchor.constraint(equalTo: productImageView.trailingAnchor, constant: 10),
+            productNameLabel.widthAnchor.constraint(lessThanOrEqualToConstant: 220), 
             
             productBrandNameLabel.topAnchor.constraint(equalTo: productNameLabel.bottomAnchor, constant: 15),
             productBrandNameLabel.leadingAnchor.constraint(equalTo: productImageView.trailingAnchor, constant: 10),

--- a/Cart Crunch/HomeScreenViewController.swift
+++ b/Cart Crunch/HomeScreenViewController.swift
@@ -6,8 +6,11 @@
 //
 
 import UIKit
+import Nuke
 
 class HomeScreenViewController: UIViewController {
+    
+    let imagePrefetcher = ImagePrefetcher()
     
     //MARK: - UIComponents
     let tableView: UITableView = {
@@ -36,6 +39,10 @@ class HomeScreenViewController: UIViewController {
     //MARK: - Product object array
     var displayedProducts: [Product] = []
     
+    func findImageURL(for images: [ImageMetaData], sizeName: String) -> String? {
+        return images.first(where: { $0.size == sizeName })?.url
+    }
+    
     //MARK: - viewDidLoad
     override func viewDidLoad() {
         super.viewDidLoad()
@@ -52,6 +59,11 @@ class HomeScreenViewController: UIViewController {
             case .success(let products):
                 DispatchQueue.main.async {
                     self.displayedProducts = products
+                    
+                    // Prefetch images
+                    let urls = products.compactMap { self.findImageURL(for: $0.images.first?.sizes ?? [], sizeName: "medium") }.compactMap { URL(string: $0) }
+                    self.imagePrefetcher.startPrefetching(with: urls)
+                    
                     self.tableView.reloadData()
                     print(self.displayedProducts)
                 }
@@ -93,7 +105,7 @@ extension HomeScreenViewController: UITableViewDelegate, UITableViewDataSource {
         }
         //configuring the cells for reuse so they are all the same
         let product = displayedProducts[indexPath.row]
-        cell.configure(with: product)
+        cell.configure(with: product, findImageURL: self.findImageURL)
         cell.backgroundColor = .white
         return cell
     }


### PR DESCRIPTION
### Description of changes

Home Screen
- Images now load a bit faster and don't display squished

### Verification

| Current Look                                                                     |
|------------------------------------------------------------------------------------------|
| <img src=https://user-images.githubusercontent.com/65370736/233503966-47ac7d0a-0435-474c-964c-fcf741a9cb78.gif height=700 > </br> |

### Pull request checklist

This PR has considered:
- [ ] Light and Dark appearances
- [ ] iOS supported versions (all major versions greater than or equal current target deployment version)
- [ ] Internationalization and Right to Left layouts
- [ ] Different resolutions (1x, 2x, 3x)
- [ ] Size classes and window sizes (iPhone vs iPad, notched devices, multitasking, different window sizes, etc)